### PR TITLE
replace `doc_auto_cfg` to `doc_cfg`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! It also adds the [`assert_tokens!`] and [`assert_expansion!`] macros to
 //! improve unit testability for `proc-macros`.
 #![warn(clippy::pedantic, missing_docs)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(rustdoc::all)]
 
 #[cfg(all(doc, feature = "proc-macro2"))]


### PR DESCRIPTION
`doc_auto_cfg` removed in 1.92.0, merged into `doc_cfg`. See <https://github.com/rust-lang/rust/pull/138907>.